### PR TITLE
Enforce usage of addon attached image widged

### DIFF
--- a/src/ImageCards/displays/Cards.jsx
+++ b/src/ImageCards/displays/Cards.jsx
@@ -4,7 +4,8 @@ import cx from 'classnames';
 import { Card, Icon, Message } from 'semantic-ui-react';
 import { UniversalLink } from '@plone/volto/components';
 import { serializeNodes } from 'volto-slate/editor/render';
-import { getScaleUrl, getPath } from '../utils';
+import { getScaleUrl } from '../utils';
+import { flattenToAppURL } from '@plone/volto/helpers';
 
 import '@eeacms/volto-block-image-cards/ImageCards/css/cards.less';
 
@@ -30,8 +31,12 @@ const Cards = (props) => {
     return (
       <img
         src={
-          getScaleUrl(getPath(attachedimage), image_scale || 'preview') ||
-          DefaultImageSVG
+          attachedimage
+            ? getScaleUrl(
+                flattenToAppURL(attachedimage),
+                image_scale || 'preview',
+              )
+            : DefaultImageSVG
         }
         alt={item.title}
       />
@@ -115,7 +120,7 @@ Cards.schema = () => ({
       title: 'Link title',
     },
     attachedimage: {
-      widget: 'attachedimage',
+      widget: 'attachedimagewidget',
       title: 'Image',
     },
     copyright: {

--- a/src/ImageCards/displays/Carousel.jsx
+++ b/src/ImageCards/displays/Carousel.jsx
@@ -7,6 +7,8 @@ import { serializeNodes } from 'volto-slate/editor/render';
 import { getScaleUrl, getPath } from '../utils';
 import { CommonCarouselschemaExtender } from './../CommonAssets/schema';
 import cx from 'classnames';
+import { flattenToAppURL } from '@plone/volto/helpers';
+import DefaultImageSVG from '@plone/volto/components/manage/Blocks/Listing/default-image.svg';
 
 import leftSVG from '@plone/volto/icons/left-key.svg';
 import rightSVG from '@plone/volto/icons/right-key.svg';
@@ -103,10 +105,14 @@ const Carousel = (props) => {
                   style={
                     card.attachedimage
                       ? {
-                          backgroundImage: `url(${getScaleUrl(
-                            getPath(card.attachedimage),
-                            image_scale || 'large',
-                          )})`,
+                          backgroundImage: `url(${
+                            card.attachedimage
+                              ? getScaleUrl(
+                                  flattenToAppURL(card.attachedimage),
+                                  image_scale || 'large',
+                                )
+                              : DefaultImageSVG
+                          })`,
                           height: `${height}px`,
                         }
                       : {}

--- a/src/ImageCards/displays/DiscreetCarousel.jsx
+++ b/src/ImageCards/displays/DiscreetCarousel.jsx
@@ -4,7 +4,9 @@ import ResponsiveContainer from '../ResponsiveContainer';
 
 import loadable from '@loadable/component';
 import { CommonCarouselschemaExtender } from './../CommonAssets/schema';
+import { flattenToAppURL } from '@plone/volto/helpers';
 
+import DefaultImageSVG from '@plone/volto/components/manage/Blocks/Listing/default-image.svg';
 import 'slick-carousel/slick/slick.css';
 import '../css/discreetcarousel.less';
 // import 'slick-carousel/slick/slick-theme.css';
@@ -34,10 +36,14 @@ const Card = ({ card = {}, height, image_scale, mode = 'view' }) => {
         <LinkWrapper>
           <Image
             className="bg-image"
-            src={getScaleUrl(
-              getPath(card.attachedimage),
-              image_scale || 'large',
-            )}
+            src={
+              card.attachedimage
+                ? getScaleUrl(
+                    flattenToAppURL(card.attachedimage),
+                    image_scale || 'large',
+                  )
+                : DefaultImageSVG
+            }
           />
         </LinkWrapper>
       </PopupWrapper>
@@ -151,14 +157,27 @@ DiscreetCarousel.schemaExtender = (schema, data, intl) => {
   };
 
   Common.fieldsets[0].fields.push('itemsPerRow');
-
   return {
     ...schema,
     ...Common,
     properties: {
       ...schema.properties,
       ...Common.properties,
+      cards: {
+        ...schema.properties.cards,
+        schema: {
+          ...schema.properties.cards.schema,
+          properties: {
+            ...schema.properties.cards.schema.properties,
+            attachedimage: {
+              ...schema.properties.cards.schema.properties.attachedimage,
+              widget: 'attachedimagewidget',
+            },
+          },
+        },
+      },
     },
+
     fieldsets: [...schema.fieldsets, ...Common.fieldsets],
   };
 };

--- a/src/ImageCards/displays/RoundTiled.jsx
+++ b/src/ImageCards/displays/RoundTiled.jsx
@@ -5,6 +5,9 @@ import { UniversalLink } from '@plone/volto/components';
 import { BodyClass } from '@plone/volto/helpers';
 import cx from 'classnames';
 import { getScaleUrl, getPath } from '../utils';
+import { flattenToAppURL } from '@plone/volto/helpers';
+import DefaultImageSVG from '@plone/volto/components/manage/Blocks/Listing/default-image.svg';
+
 import '../css/roundtiled.less';
 
 export const Card = (props) => {
@@ -41,10 +44,14 @@ export const Card = (props) => {
               style={
                 attachedimage
                   ? {
-                      backgroundImage: `url(${getScaleUrl(
-                        getPath(attachedimage),
-                        image_scale || 'preview',
-                      )})`,
+                      backgroundImage: `url(${
+                        attachedimage
+                          ? getScaleUrl(
+                              flattenToAppURL(attachedimage),
+                              image_scale || 'preview',
+                            )
+                          : DefaultImageSVG
+                      })`,
                     }
                   : {}
               }

--- a/src/ImageCards/schema.jsx
+++ b/src/ImageCards/schema.jsx
@@ -24,7 +24,7 @@ const ImageCard = () => ({
       title: 'Link',
     },
     attachedimage: {
-      widget: 'attachedimage',
+      widget: 'attachedimagewidget',
       title: 'Image',
     },
     copyright: {

--- a/src/index.js
+++ b/src/index.js
@@ -63,8 +63,8 @@ export default (config) => {
     },
   };
 
-  if (!config.widgets.widget.attachedimage) {
-    config.widgets.widget.attachedimage = AttachedImageWidget;
+  if (!config.widgets.widget.attachedimagewidget) {
+    config.widgets.widget.attachedimagewidget = AttachedImageWidget;
   }
   return config;
 };


### PR DESCRIPTION
Some cases where attachedimage already exists (FISE and volto-addons-forest), and would not use addons own attachimage widget. Preferably use the latter as it's made to work with this addons and more stable. 